### PR TITLE
Added possibility to add multiple targets (e.g. one for ipad2, one for iphone5, one for iphone6 etc) in ti_args

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -65,13 +65,13 @@ module.exports = function(grunt) {
       run: {
         command: 'run',
         options: grunt.option("p") ? {
-          platform: grunt.option("p")
+          platform: ti_args[grunt.option("p")][1]
         }: {}
       },
       spec: {
         command: 'spec',
         options: grunt.option("p") ? {
-          platform: grunt.option("p"),
+          platform: ti_args[grunt.option("p")][1],
           update: false
         }:{
           update: false,
@@ -182,7 +182,7 @@ module.exports = function(grunt) {
       update : true,
     };
     if(grunt.option("p")) {
-      ts_options.platform = grunt.option("p");
+      ts_options.platform = ti_args[grunt.option("p")][1];
     }
     var alloyCompileFile ; 
     var o = {};


### PR DESCRIPTION
This small patch adds the possibility to add multiple targets in ti_args (e.g one for ipad2, one for iphone5, one for iphone6 etc).

Currently, the property names (`ios` and `android`) doubles as the platform names:

```js
var ti_args= {
  ios: ['-p','ios','-T', 'simulator', '--device-id','F2B9C750-6BCC-4BC0-8CE8-A5D1FA30A036'],
  android: ['-p','android', '-T','device'],
  default: ['-p','ios'] 
};
```

This pull request changes this so that the platform names are fetched from the second value in the value array. This makes it possible to define targets such as:

```js
var ti_args= {
  iphone5: ['-p','ios','-T', 'simulator', '--device-id','AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE'],
  iphone6: ['-p','ios','-T', 'simulator', '--device-id','FFFFFFFF-GGGG-HHHH-IIII-JJJJJJJJJJJJ'],
  ipad2: ['-p','ios','-T', 'simulator', '--device-id','KKKKKKKK-LLLL-MMMM-NNNN-OOOOOOOOOOOO'],
  android: ['-p','android', '-T','device'],
  default: ['-p','ios'] 
};
```

and then use it as 
```bash
grunt dev -p iphone6
```