### PR TITLE
Fix duplicate --platform params in generated ti build commands

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -154,6 +154,7 @@ module.exports = function(grunt) {
       appify: {
         options:  {
           command: 'build',
+          platform: grunt.option("p"),
           args: ti_args[grunt.option("p")||'default'].concat("--appify")
         }
       }


### PR DESCRIPTION
Pipe grunt -p param into the platform param of the grunt-titanium task definition. Should partially address https://github.com/dbankier/JAST/issues/16